### PR TITLE
Bump lucene-core from 4.9.0 to 7.1.0 in /chatbotv1

### DIFF
--- a/chatbotv1/pom.xml
+++ b/chatbotv1/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-core</artifactId>
-			<version>4.9.0</version>
+			<version>7.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
Bumps lucene-core from 4.9.0 to 7.1.0.

Signed-off-by: dependabot[bot] <support@github.com>